### PR TITLE
Require account activation via email

### DIFF
--- a/app/controllers/account_activations_controller.rb
+++ b/app/controllers/account_activations_controller.rb
@@ -4,8 +4,7 @@ class AccountActivationsController < ApplicationController
   def edit
     user = User.find_by(email: params[:email])
     if user && !user.activated && user.authenticated?(:activation, params[:id])
-      user.update_attribute(:activated, true)
-      user.update_attribute(:activated_at, Time.zone.now)
+      user.activate
       log_in user
       flash[:notice] = "🙌 Your account's been activated — welcome aboard!"
       redirect_to user

--- a/app/controllers/account_activations_controller.rb
+++ b/app/controllers/account_activations_controller.rb
@@ -1,0 +1,17 @@
+class AccountActivationsController < ApplicationController
+
+  # GET /account_activations/abcdefghijklmnopqrstuvwxyz0123456789/email=?
+  def edit
+    user = User.find_by(email: params[:email])
+    if user && !user.activated && user.authenticated?(:activation, params[:id])
+      user.update_attribute(:activated, true)
+      user.update_attribute(:activated_at, Time.zone.now)
+      log_in user
+      flash[:notice] = "🙌 Your account's been activated — welcome aboard!"
+      redirect_to user
+    else
+      flash[:notice] = "❌ That activation link is invalid — sorry!"
+      redirect_to root_url
+    end
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -8,10 +8,15 @@ class SessionsController < ApplicationController
   def create
     @user = User.find_by(email: params[:session][:email].downcase)
     if @user && @user.authenticate(params[:session][:password])
-      log_in @user
-      remember(@user)
-      # Redirect to the user's original destination
-      redirect_back_or @user
+      if @user.activated?
+        log_in @user
+        remember(@user)
+        # Redirect to the user's original destination
+        redirect_back_or @user
+      else
+        flash[:notice] = "❌ You need to activate your account first — check your emails!"
+        redirect_to root_url
+      end
     else
       flash.now[:error] = '❌ Invalid email/password combination'
       render 'new'

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,12 +4,14 @@ class UsersController < ApplicationController
 
   # GET /users (paginated with geared_pagination)
   def index
-    set_page_and_extract_portion_from User.order(created_at: :desc)
+    @users = User.where(activated: true)
+    set_page_and_extract_portion_from @users.order(created_at: :desc)
   end
 
   # GET /users/1
   def show
     @user = User.find(params[:id])
+    redirect_to root_url and return unless @user.activated?
   end
 
   # GET /sign_up

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -21,7 +21,7 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
-      UserMailer.account_activation(@user).deliver_now
+      @user.send_signup_email
       flash[:notice] = "📧 Almost there! Check your email for an activation link."
       redirect_to root_url
     else

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -21,9 +21,9 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
-      log_in @user
-      flash[:notice] = "🙌 Welcome to your Day Book account! Take a look around."
-      redirect_to @user
+      UserMailer.account_activation(@user).deliver_now
+      flash[:notice] = "📧 Almost there! Check your email for an activation link."
+      redirect_to root_url
     else
       render 'new'
     end

--- a/app/helpers/account_activations_helper.rb
+++ b/app/helpers/account_activations_helper.rb
@@ -1,0 +1,2 @@
+module AccountActivationsHelper
+end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -21,13 +21,13 @@ module SessionsHelper
 
   # Returns the currently logged-in user
   # If there's no user in the temporary session we check for a permanent
-  # session in the cookies and log them in if one exists.
+  # session in the browser's cookies and log them in if one exists.
   def current_user
     if (user_id = session[:user_id])
       @current_user ||= User.find_by(id: user_id)
     elsif (user_id = cookies.signed[:user_id])
       user = User.find_by(id: user_id)
-      if user && user.authenticated?(cookies[:remember_token])
+      if user && user.authenticated?(:remember, cookies[:remember_token])
         log_in user
         @current_user = user
       end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
+  default from: 'noreply@example.com'
   layout 'mailer'
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,0 +1,24 @@
+class UserMailer < ApplicationMailer
+
+  # Subject can be set in your I18n file at config/locales/en.yml
+  # with the following lookup:
+  #
+  #   en.user_mailer.account_activation.subject
+  #
+  def account_activation(user)
+    @user = user
+
+    mail to: user.email, subject: "Activate your Day Book account"
+  end
+
+  # Subject can be set in your I18n file at config/locales/en.yml
+  # with the following lookup:
+  #
+  #   en.user_mailer.password_reset.subject
+  #
+  def password_reset
+    @greeting = "Hi"
+
+    mail to: "to@example.org"
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -45,6 +45,15 @@ class User < ApplicationRecord
     BCrypt::Password.new(digest).is_password?(token)
   end
 
+  # Activates an account
+  def activate
+    update_columns(activated: true, activated_at: Time.zone.now)
+  end
+
+  def send_signup_email
+    UserMailer.account_activation(self).deliver_now
+  end
+
   private
     # Creates and assigns the token and digest for an account activation
     def create_activation_digest

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -3,11 +3,16 @@
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <style>
-      /* Email styles need to be inline */
+      footer {color: #777; margin-top: 1em;}
     </style>
   </head>
 
   <body>
     <%= yield %>
+    <footer>
+      -----<br>
+      This was an automated message, but feel free to
+      <%= mail_to 'dcharlesworth@me.com', 'email Dan' %> if you need some help.
+    </footer>
   </body>
 </html>

--- a/app/views/layouts/mailer.text.erb
+++ b/app/views/layouts/mailer.text.erb
@@ -1,1 +1,4 @@
 <%= yield %>
+
+-----
+This was an automated message, but feel free to email Dan at dcharlesworth@me.com if you need any help.

--- a/app/views/user_mailer/account_activation.html.erb
+++ b/app/views/user_mailer/account_activation.html.erb
@@ -1,0 +1,10 @@
+<h1>Day Book</h1>
+
+<p>Hi <%= @user.name %></p>
+<p>
+  Thanks for checking out Day Book!
+</p>
+<p>
+  Would you mind opening this link to confirm this is your real email address?
+</p>
+<%= link_to "Activate my account", edit_account_activation_url(@user.activation_token, email: @user.email) %>

--- a/app/views/user_mailer/account_activation.text.erb
+++ b/app/views/user_mailer/account_activation.text.erb
@@ -1,0 +1,7 @@
+Hi <%= @user.name %>,
+
+Thanks for checking out Day Book!
+
+Would you mind clicking this link to confirm this is your real email address?
+
+<%= edit_account_activation_url(@user.activation_token, email: @user.email) %>

--- a/app/views/user_mailer/password_reset.html.erb
+++ b/app/views/user_mailer/password_reset.html.erb
@@ -1,0 +1,5 @@
+<h1>User#password_reset</h1>
+
+<p>
+  <%= @greeting %>, find me in app/views/user_mailer/password_reset.html.erb
+</p>

--- a/app/views/user_mailer/password_reset.text.erb
+++ b/app/views/user_mailer/password_reset.text.erb
@@ -1,0 +1,3 @@
+User#password_reset
+
+<%= @greeting %>, find me in app/views/user_mailer/password_reset.text.erb

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -26,10 +26,11 @@ Rails.application.configure do
     config.cache_store = :null_store
   end
 
-  # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
-
+  # Mailer config
+  config.action_mailer.raise_delivery_errors = true
   config.action_mailer.perform_caching = false
+  config.action_mailer.delivery_method = :test
+  config.action_mailer.default_url_options = { host: 'localhost:3000' }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -33,6 +33,7 @@ Rails.application.configure do
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
+  config.action_mailer.default_url_options = { host: 'localhost:3000' }
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
   get  '/signup', to: 'users#new'
   post '/signup', to: 'users#create'
   resources :users
+  resources :account_activations, only: [:edit]
 
   # Sessions
   get    '/sign_in',  to: 'sessions#new'

--- a/db/migrate/20170428055531_add_activation_to_users.rb
+++ b/db/migrate/20170428055531_add_activation_to_users.rb
@@ -1,0 +1,7 @@
+class AddActivationToUsers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :activation_digest, :string
+    add_column :users, :activated, :boolean, default: false
+    add_column :users, :activated_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170421020551) do
+ActiveRecord::Schema.define(version: 20170428055531) do
 
   create_table "articles", force: :cascade do |t|
     t.string   "title"
@@ -31,11 +31,14 @@ ActiveRecord::Schema.define(version: 20170421020551) do
   create_table "users", force: :cascade do |t|
     t.string   "name"
     t.string   "email"
-    t.datetime "created_at",                      null: false
-    t.datetime "updated_at",                      null: false
+    t.datetime "created_at",                        null: false
+    t.datetime "updated_at",                        null: false
     t.string   "password_digest"
     t.string   "remember_digest"
-    t.boolean  "admin",           default: false
+    t.boolean  "admin",             default: false
+    t.string   "activation_digest"
+    t.boolean  "activated",         default: false
+    t.datetime "activated_at"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,11 +6,16 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-User.create!(name: "Horace Wittel", email: "horace@handpnyc.com", password: "Garfunkel", admin: true)
+User.create!(name: "Horace Wittel",
+             email: "horace@handpnyc.com",
+             password: "Garfunkel",
+             admin: true,
+             activated: true,
+             activated_at: Time.zone.now)
 
 99.times do |n|
   name  = Faker::Name.name
   email = "fake-#{n+1}@example.com"
   password = "Qwerty1234"
-  User.create!(name: name, email: email, password: password)
+  User.create!(name: name, email: email, password: password, activated: true, activated_at: Time.zone.now)
 end

--- a/test/controllers/account_activations_controller_test.rb
+++ b/test/controllers/account_activations_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class AccountActivationsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -5,6 +5,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   def setup
     @user = users(:brienne)
     @other_user = users(:samwell)
+    @inactive_user = users(:daenerys)
   end
 
   test "should get the sign-up screen" do
@@ -67,5 +68,13 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
       delete user_path(@user)
     end
     assert_redirected_to root_url
+  end
+
+  test "should not show inactive users to anyone" do
+    log_in_as(@other_user, password: "DragonGlass")
+    get users_path
+    assert_select 'a[href=?]', user_path(@other_user)
+    assert_select 'a[href=?]', user_path(@inactive_user), count: 0
+    get user_path(@inactive_user)
   end
 end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -5,36 +5,50 @@ arya:
   name: Arya Stark
   email: arya@winterfell.org
   password_digest: <%= User.digest('ValarMorghulis') %>
+  activated: true
+  activated_at: <%= Time.zone.now %>
 
 brienne:
   name: Brienne Tarth
   email: brienne@evenfallhall.org
   password_digest: <%= User.digest('OathKeeper') %>
+  activated: true
+  activated_at: <%= Time.zone.now %>
 
 cersei:
   name: Cersei Lannister
   email: queen@casterlyrock.org
   password_digest: <%= User.digest('LoveIsPoison') %>
   admin: true
+  activated: true
+  activated_at: <%= Time.zone.now %>
 
 daenerys:
   name: Daenerys Targaryen
   email: princess@dragonstone.org
   password_digest: <%= User.digest('SunAndStars') %>
+  activated: false
+  activation_digest: <%= User.digest('8N8yoLNdCEAhdu6vw-oauw') %>
+
 
 ellaria:
   name: Ellaria Sand
   email: ellaria@sunspear.org
   password_digest: <%= User.digest('Vengeance') %>
+  activated: true
+  activated_at: <%= Time.zone.now %>
 
 samwell:
   name: Samwell Tarly
   email: tarly@thecitadel.gov
   password_digest: <%= User.digest('DragonGlass') %>
+  activated: true
 
 <% 50.times do |n| %>
 user_<%= n %>:
   name:  <%= "User #{n}" %>
   email: <%= "user-#{n}@example.com" %>
   password_digest: <%= User.digest('password') %>
+  activated: true
+  activated_at: <%= Time.zone.now %>
 <% end %>

--- a/test/integration/users_signin_test.rb
+++ b/test/integration/users_signin_test.rb
@@ -12,6 +12,7 @@ class UsersSignInTest < ActionDispatch::IntegrationTest
     post sign_in_path, params: { session: { email: "", password: "" } }
     assert_not flash.empty?
     assert_select 'form[action="/sign_in"]'
+    assert_select 'div.flash-content-error'
     # Make sure the flash doesn't persist after navigating away
     get root_path
     assert flash.empty?

--- a/test/integration/users_signup_test.rb
+++ b/test/integration/users_signup_test.rb
@@ -1,6 +1,9 @@
 require 'test_helper'
 
 class UsersSignupTest < ActionDispatch::IntegrationTest
+  def setup
+    ActionMailer::Base.deliveries.clear
+  end
 
   test "cannot sign up with invalid details" do
     get signup_path
@@ -12,14 +15,35 @@ class UsersSignupTest < ActionDispatch::IntegrationTest
     assert_select 'div.field_with_errors'
   end
 
-  test "can sign up with valid details" do
+  test "can sign up with valid details and receive activation email" do
     get signup_path
     assert_select 'form[action="/signup"]'
     assert_difference 'User.count', 1 do
-      post signup_path, params: { user: { name: "Llewyn Davis", email: "Llewyn@nyc.com", password: "Gaslight" } }
+      post signup_path, params: { user: { name: "Llewyn Davis", email: "llewyn@nyc.com", password: "Gaslight59" } }
     end
+    assert_equal 1, ActionMailer::Base.deliveries.size
+    user = User.find_by(email: 'llewyn@nyc.com')
+    assert_not user.activated?
     follow_redirect!
     assert_select 'div.flash-content-notice'
+    assert_not is_logged_in?
+  end
+
+  test "can activate account with valid link" do
+    user = users(:daenerys)
+    # Try to log in before activation.
+    log_in_as(user, password: 'SunAndStars')
+    assert_not is_logged_in?
+    # Invalid activation token
+    get edit_account_activation_path("invalid token", email: user.email)
+    assert_not is_logged_in?
+    # Valid token, wrong email
+    get edit_account_activation_path('8N8yoLNdCEAhdu6vw-oauw', email: 'queen@westeros.gov')
+    assert_not is_logged_in?
+    # Valid activation token
+    get edit_account_activation_path('8N8yoLNdCEAhdu6vw-oauw', email: user.email)
+    assert user.reload.activated?
+    follow_redirect!
     assert is_logged_in?
   end
 end

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -1,0 +1,15 @@
+# Preview all emails at http://localhost:3000/rails/mailers/user_mailer
+class UserMailerPreview < ActionMailer::Preview
+
+  # Preview this email at http://localhost:3000/rails/mailers/user_mailer/account_activation
+  def account_activation
+    user = User.first
+    user.activation_token = User.new_token
+    UserMailer.account_activation(user)
+  end
+
+  # Preview this email at http://localhost:3000/rails/mailers/user_mailer/password_reset
+  def password_reset
+    UserMailer.password_reset
+  end
+end

--- a/test/mailers/user_mailer_test.rb
+++ b/test/mailers/user_mailer_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+
+class UserMailerTest < ActionMailer::TestCase
+  test "account_activation" do
+    user = users(:brienne)
+    user.activation_token = User.new_token
+    mail = UserMailer.account_activation(user)
+    assert_equal "Activate your Day Book account", mail.subject
+    assert_equal [user.email], mail.to
+    assert_equal ["noreply@example.com"], mail.from
+    assert_match user.name, mail.body.encoded
+    assert_match user.activation_token, mail.body.encoded
+    assert_match CGI.escape(user.email), mail.body.encoded
+  end
+
+  test "password_reset" do
+    mail = UserMailer.password_reset
+    assert_equal "Password reset", mail.subject
+    assert_equal ["to@example.org"], mail.to
+    assert_equal ["noreply@example.com"], mail.from
+    assert_match "Hi", mail.body.encoded
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -72,6 +72,6 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test "authenticated? method should return false for a user with a nil digest" do
-    assert_not @user.authenticated?('')
+    assert_not @user.authenticated?(:remember, '')
   end
 end


### PR DESCRIPTION
I don't really want this feature but it seemed like a good way to get an intro to mailers. And it was!

Email-based account activation feels archaic for the kind of app I have in mind. I would rather people can just sign up and get started straight away. After all, this isn't going to be an app with public facing data in mind. It will be personal data being shared privately with select collaborators. I'm not concerned about account creation abuse like I would be if this were Twitter, for example.

So. Before I merge this branch I'm going to carefully remove the whole feature—which is complete with tests—but leave any methods and config that I can use for future mailers like password resets and invites.

📮